### PR TITLE
[issue 325] Disable override of custom properties 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 All notable changes to this project will be documented in this file.
 
-### [2.2.1] 2022.06.03
+### [2.2.1] 2022.06.09
 * Fixes an issue that was preventing skipping the injection for a given field. For more info about the feature see [here](README.md#skip-transformation-on-a-given-set-of-fields).
 
 ### [2.2.0] 2022.01.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 All notable changes to this project will be documented in this file.
 
+### [2.2.1] 2022.06.03
+* Fixes an issue that was preventing skipping the injection for a given field. For more info about the feature see [here](README.md#skip-transformation-on-a-given-set-of-fields).
+
 ### [2.2.0] 2022.01.10
 #### Changed
 * Updated `hibernate-validator` version to `6.2.1.Final` (was `7.0.1.Final`). This replaces the jakarta validation with the javax one.

--- a/bull-bean-transformer/src/main/java/com/expediagroup/beans/transformer/TransformerImpl.java
+++ b/bull-bean-transformer/src/main/java/com/expediagroup/beans/transformer/TransformerImpl.java
@@ -427,9 +427,7 @@ public class TransformerImpl extends AbstractBeanTransformer {
         String fieldBreadcrumb = evalBreadcrumb(field.getName(), breadcrumb);
         Class<?> fieldType = field.getType();
         if (doSkipTransformation(fieldBreadcrumb)) {
-            return Optional.ofNullable(targetObject)
-                    .map(to -> reflectionUtils.getFieldValue(to, fieldBreadcrumb, fieldType))
-                    .orElseGet(() -> defaultValue(fieldType));
+            return getDefaultFieldValue(targetObject, fieldBreadcrumb, fieldType);
         }
         boolean primitiveType = classUtils.isPrimitiveType(fieldType);
         FieldTransformer transformerFunction = getTransformerFunction(field, fieldBreadcrumb);
@@ -448,6 +446,20 @@ public class TransformerImpl extends AbstractBeanTransformer {
         }
         fieldValue = getTransformedValue(transformerFunction, fieldValue, sourceObj.getClass(), sourceFieldName, field, primitiveType, fieldBreadcrumb);
         return fieldValue;
+    }
+
+    private <K> Object getDefaultFieldValue(final K targetObject, final String fieldBreadcrumb, final Class<?> fieldType) {
+        return Optional.ofNullable(targetObject)
+                .map(to -> {
+                    Object val;
+                    try {
+                        val = reflectionUtils.getFieldValue(to, fieldBreadcrumb, fieldType);
+                    } catch (Exception e) {
+                        val = defaultValue(fieldType);
+                    }
+                    return val;
+                })
+                .orElseGet(() -> defaultValue(fieldType));
     }
 
     /**

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/AbstractBeanTransformerTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/AbstractBeanTransformerTest.java
@@ -53,5 +53,7 @@ public abstract class AbstractBeanTransformerTest extends AbstractTransformerTes
     @BeforeMethod
     void beforeMethod() {
         openMocks(this);
+        underTest.resetFieldsTransformer();
+        underTest.resetFieldsTransformationSkip();
     }
 }

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/ImmutableObjectTransformationTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/ImmutableObjectTransformationTest.java
@@ -83,7 +83,6 @@ public class ImmutableObjectTransformationTest extends AbstractBeanTransformerTe
     @AfterMethod
     public void afterMethod() {
         underTest.setValidationEnabled(false);
-        underTest.resetFieldsTransformer();
     }
 
     /**
@@ -480,7 +479,6 @@ public class ImmutableObjectTransformationTest extends AbstractBeanTransformerTe
 
         // THEN
         assertThat(actual).hasNoNullFieldsOrPropertiesExcept(NAME_FIELD_NAME, PHONE_NUMBER_NESTED_OBJECT_FIELD_NAME);
-        underTest.resetFieldsTransformationSkip();
     }
 
     /**
@@ -500,7 +498,6 @@ public class ImmutableObjectTransformationTest extends AbstractBeanTransformerTe
 
         // THEN
         assertThat(actual.getWork()).isTrue();
-        underTest.resetFieldsTransformer();
     }
 
     /**

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MixedObjectTransformationTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MixedObjectTransformationTest.java
@@ -170,7 +170,6 @@ public class MixedObjectTransformationTest extends AbstractBeanTransformerTest {
 
         // THEN
         assertThat(actual).hasNoNullFieldsOrPropertiesExcept(NAME_FIELD_NAME, PHONE_NUMBER_NESTED_OBJECT_FIELD_NAME);
-        underTest.resetFieldsTransformationSkip();
     }
 
     /**

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MixedObjectTransformationTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MixedObjectTransformationTest.java
@@ -179,14 +179,18 @@ public class MixedObjectTransformationTest extends AbstractBeanTransformerTest {
     @Test
     public void testTransformationOnAnExistingDestinationWorksProperly() {
         // GIVEN
-        MixedToFoo mixedToFoo = new MixedToFoo(null, null, null, null, null);
+        final BigInteger presetFieldId = BigInteger.valueOf(777);
+        final String fieldNameToIgnore = "id";
+        MixedToFoo mixedToFoo = new MixedToFoo(presetFieldId, null, null, null, null);
 
         // WHEN
-        underTest.skipTransformationForField().transform(fromFoo, mixedToFoo);
+        underTest.skipTransformationForField(fieldNameToIgnore).transform(fromFoo, mixedToFoo);
 
         // THEN
         assertThat(mixedToFoo).usingRecursiveComparison()
+                .ignoringFields(fieldNameToIgnore)
                 .isEqualTo(fromFoo);
+        assertThat(mixedToFoo.getId()).isEqualTo(presetFieldId);
     }
 
     /**

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MutableObjectTransformationTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MutableObjectTransformationTest.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -60,6 +61,13 @@ public class MutableObjectTransformationTest extends AbstractBeanTransformerTest
     private static final String INJECT_VALUES_METHOD_NAME = "injectValues";
     private static final String NESTED_OBJECT_NAME_FIELD_NAME = "nestedObject.name";
     private static final String CODE_FIELD_NAME = "code";
+
+    @BeforeMethod
+    void beforeMethod() {
+        super.beforeMethod();
+        underTest.resetFieldsTransformer();
+        underTest.resetFieldsTransformationSkip();
+    }
 
     /**
      * Test that an exception is thrown if there is no default constructor defined for the mutable bean object.
@@ -139,7 +147,6 @@ public class MutableObjectTransformationTest extends AbstractBeanTransformerTest
         assertThat(actual)
                 .extracting(NAME_FIELD_NAME, NESTED_OBJECT_NAME_FIELD_NAME)
                 .containsExactly(fromFoo.getName(), namePrefix + fromFoo.getNestedObject().getName());
-        underTest.resetFieldsTransformer();
     }
 
     /**
@@ -161,7 +168,6 @@ public class MutableObjectTransformationTest extends AbstractBeanTransformerTest
         assertThat(actual.getName()).isEqualTo(namePrefix + fromFoo.getName());
         assertThat(actual.getNestedObject().getName())
                 .isEqualTo(namePrefix + fromFoo.getNestedObject().getName());
-        underTest.resetFieldsTransformer();
     }
 
     /**
@@ -230,7 +236,6 @@ public class MutableObjectTransformationTest extends AbstractBeanTransformerTest
 
         // THEN
         assertThat(mutableObjectBean).hasFieldOrPropertyWithValue(AGE_FIELD_NAME, AGE);
-        underTest.resetFieldsTransformer();
     }
 
     /**

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MutableObjectTransformationTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MutableObjectTransformationTest.java
@@ -31,7 +31,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -61,13 +60,6 @@ public class MutableObjectTransformationTest extends AbstractBeanTransformerTest
     private static final String INJECT_VALUES_METHOD_NAME = "injectValues";
     private static final String NESTED_OBJECT_NAME_FIELD_NAME = "nestedObject.name";
     private static final String CODE_FIELD_NAME = "code";
-
-    @BeforeMethod
-    void beforeMethod() {
-        super.beforeMethod();
-        underTest.resetFieldsTransformer();
-        underTest.resetFieldsTransformationSkip();
-    }
 
     /**
      * Test that an exception is thrown if there is no default constructor defined for the mutable bean object.
@@ -323,7 +315,6 @@ public class MutableObjectTransformationTest extends AbstractBeanTransformerTest
 
         // THEN
         assertThat(actual).hasNoNullFieldsOrPropertiesExcept(NAME_FIELD_NAME, PHONE_NUMBER_NESTED_OBJECT_FIELD_NAME);
-        underTest.resetFieldsTransformationSkip();
     }
 
     /**

--- a/bull-common/src/test/java/com/expediagroup/transformer/utils/ClassUtilsTest.java
+++ b/bull-common/src/test/java/com/expediagroup/transformer/utils/ClassUtilsTest.java
@@ -509,7 +509,7 @@ public class ClassUtilsTest {
     private Object[][] dataAreParameterNamesAvailableTesting() {
         return new Object[][] {
                 {"Tests that the method returns false if the constructor parameter names are not available", createMockedConstructor(), false},
-//                {"Tests that the method returns false if the constructor parameter names are available", underTest.getAllArgsConstructor(MixedToFoo.class), true}
+                {"Tests that the method returns false if the constructor parameter names are available", underTest.getAllArgsConstructor(MixedToFoo.class), true}
         };
     }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes an issue that was preventing keeping an existing value in the target Bean for a given field. For more info about the feature see [here](README.md#skip-transformation-on-a-given-set-of-fields) and #325 

Fixes #325 

## How Has This Been Tested?

- [X] The existing value for a field is kept in case it is marked to be skipped
- [X] Test that the feature is working properly even on nested objects
- [X] Retrocompatibility test

## Checklist:

- [ ] The branch follows the best practices naming convention:
     - Use grouping tokens (words) at the beginning of your branch names.
        * `feature`: Feature I'm adding or expanding
        * `bug`: Bugfix or experiment
        * `wip`: Work in progress; stuff I know won't be finished soon
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My changes have no bad impacts on performances
- [ ] My changes have been tested through Unit Tests and the overall coverage has not decreased. Check the coverall report for your branch: [here](https://coveralls.io/github/ExpediaGroup/bull)
- [ ] Any implemented change has been added in the [CHANGELOG.md](./CHANGELOG.md) file 
- [ ] Any implemented change has been added in the [CHANGELOG-JDK11.md](./CHANGELOG-JDK11.md) file 
- [ ] My changes have been applied on a separate branch too with compatibility with Java 11. Follow this [instructions](https://github.com/ExpediaGroup/bull/blob/master/RELEASE.md#3-prepare-the-jdk11-release) for help.
- [ ] The maven version has been increased. 
