### PR TITLE
Fix/collection element field transformer null regression

### DIFF
--- a/CHANGELOG-JDK11.md
+++ b/CHANGELOG-JDK11.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+### [2.1.6-jdk11] 2026.03.31
+* Fixes a regression introduced in 2.1.5-jdk11 where field transformers applied to collection elements were incorrectly resolved against the root source object instead of the current element, causing a NullPointerException when a flat field name mapping existed with the same name as the destination field
+
 ### [2.1.5-jdk11] 2026.03.30
 * Fixes an issue that was preventing the transformation of Kotlin classes with default parameter values
 * Fixes MissingFieldException when mapping a root-level primitive field into a nested destination object via `withFieldMapping` (issue #559)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+### [3.0.2] 2026.03.31
+* Fixes a regression introduced in 3.0.1 where field transformers applied to collection elements were incorrectly resolved against the root source object instead of the current element, causing a NullPointerException when a flat field name mapping existed with the same name as the destination field
+
 ### [3.0.1] 2026.03.30
 * Fixes an issue that was preventing the transformation of Kotlin classes with default parameter values
 * Fixes MissingFieldException when mapping a root-level primitive field into a nested destination object via `withFieldMapping` (issue #559)

--- a/bull-bean-transformer/pom.xml
+++ b/bull-bean-transformer/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.expediagroup.beans</groupId>
         <artifactId>bean-utils-library-parent</artifactId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>3.0.2</version>
     </parent>
 
     <dependencies>

--- a/bull-bean-transformer/pom.xml
+++ b/bull-bean-transformer/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.expediagroup.beans</groupId>
         <artifactId>bean-utils-library-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bull-bean-transformer/src/main/java/com/expediagroup/beans/transformer/TransformerImpl.java
+++ b/bull-bean-transformer/src/main/java/com/expediagroup/beans/transformer/TransformerImpl.java
@@ -93,9 +93,11 @@ public class TransformerImpl extends AbstractBeanTransformer {
     @SuppressWarnings("unchecked")
     private <T> EffectiveSource<T> resolveEffectiveSource(final T sourceObj, final String destFieldName, final String breadcrumb) {
         String fieldBreadcrumb = evalBreadcrumb(destFieldName, breadcrumb);
-        String mapped = settings.getFieldsNameMapping().get(fieldBreadcrumb);
-        if (mapped != null && rootSourceObj.get() != null) {
-            return new EffectiveSource<>((T) rootSourceObj.get(), mapped);
+        if (isNotEmpty(breadcrumb)) {
+            String mapped = settings.getFieldsNameMapping().get(fieldBreadcrumb);
+            if (mapped != null && rootSourceObj.get() != null) {
+                return new EffectiveSource<>((T) rootSourceObj.get(), mapped);
+            }
         }
         return new EffectiveSource<>(sourceObj, getSourceFieldName(destFieldName));
     }

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/AbstractBeanTransformerTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/AbstractBeanTransformerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2023 Expedia, Inc.
+ * Copyright (C) 2019-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,5 +55,6 @@ public abstract class AbstractBeanTransformerTest extends AbstractTransformerTes
         openMocks(this);
         underTest.resetFieldsTransformer();
         underTest.resetFieldsTransformationSkip();
+        underTest.resetFieldsMapping();
     }
 }

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MixedObjectTransformationTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MixedObjectTransformationTest.java
@@ -17,6 +17,7 @@ package com.expediagroup.beans.transformer;
 
 import static java.math.BigInteger.ONE;
 
+import static org.apache.commons.lang3.StringUtils.SPACE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigInteger;
@@ -24,11 +25,15 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
+import com.expediagroup.beans.sample.FromFooContainingList;
 import com.expediagroup.beans.sample.FromFooSimple;
 import com.expediagroup.beans.sample.FromFooSimpleNested;
+import com.expediagroup.beans.sample.FromFooWithFullName;
 import com.expediagroup.beans.sample.FromFooWithPrimitiveAndNestedObject;
 import com.expediagroup.beans.sample.ToFooNestedWithDiffFieldName;
 import com.expediagroup.beans.sample.ToFooWithNestedFieldMapping;
+import com.expediagroup.beans.sample.immutable.ImmutableToFooContainingList;
+import com.expediagroup.beans.sample.immutable.ImmutableToFooWithSplitName;
 import com.expediagroup.beans.sample.mixed.MixedToFoo;
 import com.expediagroup.beans.sample.mixed.MixedToFooDiffFields;
 import com.expediagroup.beans.sample.mixed.MixedToFooMissingAllArgsConstructor;
@@ -383,6 +388,67 @@ public class MixedObjectTransformationTest extends AbstractBeanTransformerTest {
         // THEN
         assertThat(actual.getNestedObject().getX()).isEqualTo(EXPECTED_X_VALUE);
         assertThat(actual.getNestedObject().getName()).isEqualTo("Lucas");
+        underTest.reset();
+    }
+
+    /**
+     * Test that a field transformer applied with flat field name transformation correctly uses
+     * the collection element as the source, not the root object.
+     * Regression test: in 3.0.1, resolveEffectiveSource matched the flat mapping ("name" -> "fullName")
+     * when the breadcrumb was null (collection element path), redirecting the source lookup to the
+     * root object which had no "fullName" field. The silenced MissingFieldException left the value
+     * as null, causing an NPE in the transformer function.
+     */
+    @Test
+    public void testFieldTransformerOnCollectionElementsUsesElementNotRootAsSource() {
+        // GIVEN
+        FromFooContainingList source = new FromFooContainingList("root-id",
+                List.of(new FromFooWithFullName("Donald Duck"), new FromFooWithFullName("Daisy Duck")));
+
+        // WHEN
+        ImmutableToFooContainingList actual = underTest
+                .setFlatFieldNameTransformation(true)
+                .withFieldMapping(new FieldMapping<>("fullName", "name"))
+                .withFieldMapping(new FieldMapping<>("fullName", "surname"))
+                .withFieldTransformer(new FieldTransformer<String, String>("name", fullName -> fullName.split(SPACE)[0]))
+                .withFieldTransformer(new FieldTransformer<String, String>("surname", fullName -> fullName.split(SPACE)[1]))
+                .transform(source, ImmutableToFooContainingList.class);
+
+        // THEN
+        assertThat(actual.getId()).isEqualTo("root-id");
+        assertThat(actual.getItems()).hasSize(2);
+        assertThat(actual.getItems().get(0).getName()).isEqualTo("Donald");
+        assertThat(actual.getItems().get(0).getSurname()).isEqualTo("Duck");
+        assertThat(actual.getItems().get(1).getName()).isEqualTo("Daisy");
+        assertThat(actual.getItems().get(1).getSurname()).isEqualTo("Duck");
+        underTest.reset();
+    }
+
+    /**
+     * Test that multiple items in a collection are all correctly transformed using their own
+     * element as the source, not the root. Verifies no cross-contamination between elements.
+     */
+    @Test
+    public void testAllCollectionElementsAreIndependentlyTransformedFromTheirOwnSource() {
+        // GIVEN
+        FromFooContainingList source = new FromFooContainingList("root-id",
+                List.of(new FromFooWithFullName("Tony Stark"), new FromFooWithFullName("Bruce Banner"),
+                        new FromFooWithFullName("Steve Rogers")));
+
+        // WHEN
+        ImmutableToFooContainingList actual = underTest
+                .setFlatFieldNameTransformation(true)
+                .withFieldMapping(new FieldMapping<>("fullName", "name"))
+                .withFieldMapping(new FieldMapping<>("fullName", "surname"))
+                .withFieldTransformer(new FieldTransformer<String, String>("name", fullName -> fullName.split(SPACE)[0]))
+                .withFieldTransformer(new FieldTransformer<String, String>("surname", fullName -> fullName.split(SPACE)[1]))
+                .transform(source, ImmutableToFooContainingList.class);
+
+        // THEN
+        assertThat(actual.getItems()).extracting(ImmutableToFooWithSplitName::getName)
+                .containsExactly("Tony", "Bruce", "Steve");
+        assertThat(actual.getItems()).extracting(ImmutableToFooWithSplitName::getSurname)
+                .containsExactly("Stark", "Banner", "Rogers");
         underTest.reset();
     }
 }

--- a/bull-bom/pom.xml
+++ b/bull-bom/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.expediagroup.beans</groupId>
         <artifactId>bean-utils-library-parent</artifactId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>3.0.2</version>
     </parent>
 
     <dependencyManagement>

--- a/bull-bom/pom.xml
+++ b/bull-bom/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.expediagroup.beans</groupId>
         <artifactId>bean-utils-library-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3-SNAPSHOT</version>
     </parent>
 
     <dependencyManagement>

--- a/bull-common/pom.xml
+++ b/bull-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.expediagroup.beans</groupId>
         <artifactId>bean-utils-library-parent</artifactId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>3.0.2</version>
     </parent>
 
     <dependencies>

--- a/bull-common/pom.xml
+++ b/bull-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.expediagroup.beans</groupId>
         <artifactId>bean-utils-library-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bull-common/src/test/java/com/expediagroup/beans/sample/FromFooContainingList.java
+++ b/bull-common/src/test/java/com/expediagroup/beans/sample/FromFooContainingList.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2019-2026 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.beans.sample;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Source bean containing a list of items with a full name field.
+ * Used to test that flat field transformers on collection elements use the element
+ * as the source, not the root object.
+ */
+@AllArgsConstructor
+@Getter
+@ToString
+public class FromFooContainingList {
+    private final String id;
+    private final List<FromFooWithFullName> items;
+}

--- a/bull-common/src/test/java/com/expediagroup/beans/sample/FromFooWithFullName.java
+++ b/bull-common/src/test/java/com/expediagroup/beans/sample/FromFooWithFullName.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2019-2026 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.beans.sample;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Source bean with a full name field, used to test flat field name transformation
+ * combined with field mapping across collection elements.
+ */
+@AllArgsConstructor
+@Getter
+@ToString
+public class FromFooWithFullName {
+    private final String fullName;
+}

--- a/bull-common/src/test/java/com/expediagroup/beans/sample/immutable/ImmutableToFooContainingList.java
+++ b/bull-common/src/test/java/com/expediagroup/beans/sample/immutable/ImmutableToFooContainingList.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2019-2026 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.beans.sample.immutable;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Destination bean containing a list of items with split name fields.
+ */
+@AllArgsConstructor
+@Getter
+@ToString
+public class ImmutableToFooContainingList {
+    private final String id;
+    private final List<ImmutableToFooWithSplitName> items;
+}

--- a/bull-common/src/test/java/com/expediagroup/beans/sample/immutable/ImmutableToFooWithSplitName.java
+++ b/bull-common/src/test/java/com/expediagroup/beans/sample/immutable/ImmutableToFooWithSplitName.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2019-2026 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.beans.sample.immutable;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Destination bean with split name fields, mapped from a single {@code fullName} source field.
+ */
+@AllArgsConstructor
+@Getter
+@ToString
+public class ImmutableToFooWithSplitName {
+    private final String name;
+    private final String surname;
+}

--- a/bull-converter/pom.xml
+++ b/bull-converter/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.expediagroup.beans</groupId>
         <artifactId>bean-utils-library-parent</artifactId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>3.0.2</version>
     </parent>
 
     <dependencies>

--- a/bull-converter/pom.xml
+++ b/bull-converter/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.expediagroup.beans</groupId>
         <artifactId>bean-utils-library-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bull-map-transformer/pom.xml
+++ b/bull-map-transformer/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>bean-utils-library-parent</artifactId>
         <groupId>com.expediagroup.beans</groupId>
-        <version>3.0.2</version>
+        <version>3.0.3-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bull-map-transformer/pom.xml
+++ b/bull-map-transformer/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>bean-utils-library-parent</artifactId>
         <groupId>com.expediagroup.beans</groupId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>3.0.2</version>
     </parent>
 
     <dependencies>

--- a/bull-report/pom.xml
+++ b/bull-report/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>bean-utils-library-parent</artifactId>
         <groupId>com.expediagroup.beans</groupId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>3.0.2</version>
     </parent>
 
     <properties>

--- a/bull-report/pom.xml
+++ b/bull-report/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>bean-utils-library-parent</artifactId>
         <groupId>com.expediagroup.beans</groupId>
-        <version>3.0.2</version>
+        <version>3.0.3-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.expediagroup.beans</groupId>
     <artifactId>bean-utils-library-parent</artifactId>
     <url>https://github.com/ExpediaGroup/bull</url>
-    <version>3.0.2</version>
+    <version>3.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <inceptionYear>2019</inceptionYear>
     <description>
@@ -112,7 +112,7 @@
         <connection>scm:git:git@github.com:ExpediaGroup/bull.git</connection>
         <developerConnection>scm:git:git@github.com:ExpediaGroup/bull.git</developerConnection>
         <url>https://github.com/ExpediaGroup/bull</url>
-        <tag>3.0.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.expediagroup.beans</groupId>
     <artifactId>bean-utils-library-parent</artifactId>
     <url>https://github.com/ExpediaGroup/bull</url>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.0.2</version>
     <packaging>pom</packaging>
     <inceptionYear>2019</inceptionYear>
     <description>
@@ -112,7 +112,7 @@
         <connection>scm:git:git@github.com:ExpediaGroup/bull.git</connection>
         <developerConnection>scm:git:git@github.com:ExpediaGroup/bull.git</developerConnection>
         <url>https://github.com/ExpediaGroup/bull</url>
-        <tag>HEAD</tag>
+        <tag>3.0.2</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
## Description
Guard the breadcrumb-based mapping lookup with `isNotEmpty(breadcrumb)`. When breadcrumb is null (collection element transforms and root-level transforms), the method falls through to `getSourceFieldName()`, which already performs the same mapping lookup correctly using the element as the source.                                                                                 
                                                                                                                                                                                                  
This has no impact on root-level or nested-object transforms: at root level `rootSourceObj == sourceObj` so both paths were equivalent; at nested level the breadcrumb is always non-null so the  guard has no effect.                                   
                                                                                                                                                                                                  
## How Has This Been Tested?
- Added two regression tests in MixedObjectTransformationTest covering the exact failure scenario with multi-element lists                                                                      
- Fixed test state leakage in AbstractBeanTransformerTest.beforeMethod() by resetting field mappings alongside existing field transformer resets                                                
- All 663 existing tests pass   

## Checklist:

- [x] The branch follows the best practices naming convention:
     - Use grouping tokens (words) at the beginning of your branch names.
        * `feature`: Feature I'm adding or expanding
        * `bug`: Bugfix or experiment
        * `wip`: Work in progress; stuff I know won't be finished soon
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My changes have no bad impacts on performances
- [x] My changes have been tested through Unit Tests and the overall coverage has not decreased. Check the coverall report for your branch: [here](https://coveralls.io/github/ExpediaGroup/bull)
- [x] Any implemented change has been added in the [CHANGELOG.md](../CHANGELOG.md) file 
- [x] Any implemented change has been added in the [CHANGELOG-JDK11.md](../CHANGELOG-JDK11.md) file 
- [x] My changes have been applied on a separate branch too with compatibility with Java 11. Follow this [instructions](https://github.com/ExpediaGroup/bull/blob/master/RELEASE.md#3-prepare-the-jdk11-release) for help.
- [ ] The maven version has been increased. 
