### PR TITLE
Improvement/reflection and performance fixes

### DIFF
--- a/CHANGELOG-JDK11.md
+++ b/CHANGELOG-JDK11.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+### [2.1.7-jdk11] 2026.04.01
+* Refactors `TransformerImpl` to use direct field access via reflection utilities instead of string-literal field names, improving maintainability and robustness
+* Eliminates redundant `ThreadLocal` initialisation by reusing the existing `rootSourceStack` instance
+* Raises JaCoCo code coverage thresholds to 100% across all modules and adds the corresponding branch-coverage tests
+
 ### [2.1.6-jdk11] 2026.03.31
 * Fixes a regression introduced in 2.1.5-jdk11 where field transformers applied to collection elements were incorrectly resolved against the root source object instead of the current element, causing a NullPointerException when a flat field name mapping existed with the same name as the destination field
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+### [3.0.3] 2026.04.01
+* Refactors `TransformerImpl` to use direct field access via reflection utilities instead of string-literal field names, improving maintainability and robustness
+* Eliminates redundant `ThreadLocal` initialisation by reusing the existing `rootSourceStack` instance
+* Raises JaCoCo code coverage thresholds to 100% across all modules and adds the corresponding branch-coverage tests
+
 ### [3.0.2] 2026.03.31
 * Fixes a regression introduced in 3.0.1 where field transformers applied to collection elements were incorrectly resolved against the root source object instead of the current element, causing a NullPointerException when a flat field name mapping existed with the same name as the destination field
 

--- a/bull-bean-transformer/pom.xml
+++ b/bull-bean-transformer/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/bull-bean-transformer/src/main/java/com/expediagroup/beans/populator/Populator.java
+++ b/bull-bean-transformer/src/main/java/com/expediagroup/beans/populator/Populator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2023 Expedia, Inc.
+ * Copyright (C) 2019-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,18 @@ import com.expediagroup.transformer.utils.ReflectionUtils;
  */
 public abstract class Populator<O> {
     /**
+     * Shared singleton — ReflectionUtils is stateless (all cache state lives in static fields),
+     * so a single instance is safe to reuse across all Populator instances and threads.
+     */
+    private static final ReflectionUtils SHARED_REFLECTION_UTILS = new ReflectionUtils();
+
+    /**
+     * Shared singleton — ClassUtils is stateless (all cache state lives in static fields),
+     * so a single instance is safe to reuse across all Populator instances and threads.
+     */
+    private static final ClassUtils SHARED_CLASS_UTILS = new ClassUtils();
+
+    /**
      * Reflection utils instance {@link ReflectionUtils}.
      */
     final ReflectionUtils reflectionUtils;
@@ -49,8 +61,8 @@ public abstract class Populator<O> {
      */
     Populator(final BeanTransformer beanTransformer) {
         transformer = beanTransformer;
-        reflectionUtils = new ReflectionUtils();
-        classUtils = new ClassUtils();
+        reflectionUtils = SHARED_REFLECTION_UTILS;
+        classUtils = SHARED_CLASS_UTILS;
     }
 
     /**

--- a/bull-bean-transformer/src/main/java/com/expediagroup/beans/transformer/TransformerImpl.java
+++ b/bull-bean-transformer/src/main/java/com/expediagroup/beans/transformer/TransformerImpl.java
@@ -38,6 +38,8 @@ import static com.expediagroup.transformer.constant.Punctuation.RPAREN;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Parameter;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -47,38 +49,70 @@ import com.expediagroup.transformer.error.InvalidBeanException;
 import com.expediagroup.transformer.error.MissingFieldException;
 import com.expediagroup.transformer.model.FieldTransformer;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * Utility methods for populating Mutable, Immutable and Hybrid JavaBeans properties via reflection.
  * The implementations are provided by BeanUtils.
  */
+@Slf4j
 public class TransformerImpl extends AbstractBeanTransformer {
     /**
-     * Holds the root source object for the current transformation.
-     * Used to resolve field mappings that reference root-level source fields
-     * from within nested destination objects.
-     *
-     * Note: if a FieldTransformer callback re-invokes transform() on this same
-     * instance for a different source object, the inner call will still see
-     * the outer root. This is acceptable for current use cases.
+     * Sentinel used to cache a null result from {@link #getDestFieldName}: means the constructor
+     * parameter has no compiled name and carries no {@link ConstructorArg} annotation.
      */
-    private final ThreadLocal<Object> rootSourceObj = new ThreadLocal<>();
+    private static final String ABSENT_FIELD_NAME = "\0";
+
+    /**
+     * Marker class whose {@link Class} object is cached by {@link #getSourceFieldType} when the
+     * field does not exist in the source and default-value-for-missing-field mode is active.
+     * Using a dedicated type avoids confusing a "not-found" result with any real field type.
+     */
+    private static final class AbsentFieldType { }
+
+    /**
+     * The {@link Class} token for {@link AbsentFieldType}, used as a sentinel value in
+     * {@link #getSourceFieldType} to represent a cached {@code null} result.
+     */
+    private static final Class<?> ABSENT_SOURCE_FIELD_TYPE = AbsentFieldType.class;
+
+    /**
+     * Sentinel {@link FieldTransformer} cached by {@link #getPrimitiveTypeTransformer} when no
+     * primitive-type conversion is applicable for a given field. Acts as an identity transform so
+     * the caller's {@code nonNull} check still short-circuits correctly without applying any
+     * conversion, and the sentinel is distinguishable from a real transformer via identity ({@code ==}).
+     */
+    @SuppressWarnings("rawtypes")
+    private static final FieldTransformer NO_OP_FIELD_TRANSFORMER_SENTINEL =
+            new FieldTransformer<Object, Object>("__no_conversion__", x -> x);
+
+    /**
+     * Holds a per-thread stack of root source objects for active transformations.
+     * The bottom of the stack is the outermost root; each nested transform that starts
+     * a new logical root (breadcrumb == null) pushes its own source and pops it in {@code finally}.
+     *
+     * <p>Note: collection elements are transformed via {@link com.expediagroup.beans.populator.Populator}
+     * with a null breadcrumb, which means they also push their own source. As a result,
+     * breadcrumb-based field mappings (root-source redirects) are intentionally guarded by
+     * {@code isNotEmpty(breadcrumb)} so they are never triggered for flat / collection-element calls.
+     *
+     * <p>Re-entrancy limitation: a {@link FieldTransformer} callback that calls
+     * {@code transform(otherObj, OtherClass.class)} on <em>this</em> instance will push {@code otherObj}
+     * as the new root for its own transformation chain, which is correct. However, any breadcrumb-based
+     * field mappings active at that point will resolve against {@code otherObj}'s root rather than the
+     * outer root. This is acceptable for current use-cases; a complete fix would require passing
+     * root-source context explicitly through the call chain rather than via a ThreadLocal.
+     */
+    private final ThreadLocal<Deque<Object>> rootSourceStack = ThreadLocal.withInitial(ArrayDeque::new);
 
     /**
      * Holds the resolved effective source object and field name after checking
      * breadcrumb-based field mappings against the root source.
      * @param <T> the source object type
+     * @param source the source object to read the field from
+     * @param fieldName the field name to read from the source
      */
-    private static final class EffectiveSource<T> {
-        /** The source object to read the field from. */
-        final T source;
-        /** The field name to read from the source. */
-        final String fieldName;
-
-        EffectiveSource(final T src, final String fName) {
-            this.source = src;
-            this.fieldName = fName;
-        }
-    }
+    private record EffectiveSource<T>(T source, String fieldName) { }
 
     /**
      * Resolves the effective source object and field name for a destination field.
@@ -92,11 +126,12 @@ public class TransformerImpl extends AbstractBeanTransformer {
      */
     @SuppressWarnings("unchecked")
     private <T> EffectiveSource<T> resolveEffectiveSource(final T sourceObj, final String destFieldName, final String breadcrumb) {
-        String fieldBreadcrumb = evalBreadcrumb(destFieldName, breadcrumb);
         if (isNotEmpty(breadcrumb)) {
+            String fieldBreadcrumb = evalBreadcrumb(destFieldName, breadcrumb);
             String mapped = settings.getFieldsNameMapping().get(fieldBreadcrumb);
-            if (mapped != null && rootSourceObj.get() != null) {
-                return new EffectiveSource<>((T) rootSourceObj.get(), mapped);
+            Deque<Object> stack = rootSourceStack.get();
+            if (mapped != null && !stack.isEmpty()) {
+                return new EffectiveSource<>((T) stack.peek(), mapped);
             }
         }
         return new EffectiveSource<>(sourceObj, getSourceFieldName(destFieldName));
@@ -108,9 +143,10 @@ public class TransformerImpl extends AbstractBeanTransformer {
     @Override
     @SuppressWarnings("unchecked")
     protected final <T, K> K transform(final T sourceObj, final Class<? extends K> targetClass, final String breadcrumb) {
-        boolean isRoot = rootSourceObj.get() == null;
+        final Deque<Object> stack = rootSourceStack.get();
+        final boolean isRoot = stack.isEmpty();
         if (isRoot) {
-            rootSourceObj.set(sourceObj);
+            stack.push(sourceObj);
         }
         try {
             final K k;
@@ -130,7 +166,7 @@ public class TransformerImpl extends AbstractBeanTransformer {
             return k;
         } finally {
             if (isRoot) {
-                rootSourceObj.remove();
+                stack.pop();
             }
         }
     }
@@ -165,9 +201,10 @@ public class TransformerImpl extends AbstractBeanTransformer {
      */
     @Override
     protected final <T, K> void transform(final T sourceObj, final K targetObject, final String breadcrumb) {
-        boolean isRoot = rootSourceObj.get() == null;
+        final Deque<Object> stack = rootSourceStack.get();
+        final boolean isRoot = stack.isEmpty();
         if (isRoot) {
-            rootSourceObj.set(sourceObj);
+            stack.push(sourceObj);
         }
         try {
             injectAllFields(sourceObj, targetObject, breadcrumb);
@@ -176,7 +213,7 @@ public class TransformerImpl extends AbstractBeanTransformer {
             }
         } finally {
             if (isRoot) {
-                rootSourceObj.remove();
+                stack.pop();
             }
         }
     }
@@ -312,20 +349,18 @@ public class TransformerImpl extends AbstractBeanTransformer {
      */
     protected <T, K> Object[] getConstructorArgsValues(final T sourceObj, final Class<K> targetClass, final Constructor constructor, final String breadcrumb) {
         final Parameter[] constructorParameters = classUtils.getConstructorParameters(constructor);
-        final var constructorArgsValues = new Object[constructorParameters.length];
-        range(0, constructorParameters.length)
+        // mapToObj makes the stream safe to parallelize in the future (no side-effectful array writes).
+        return range(0, constructorParameters.length)
                 //.parallel()
-                .forEach(i -> {
+                .mapToObj(i -> {
                     String destFieldName = getDestFieldName(constructorParameters[i], targetClass.getName());
                     if (isNull(destFieldName)) {
-                        constructorArgsValues[i] = classUtils.getDefaultTypeValue(constructorParameters[i].getType());
-                    } else {
-                        EffectiveSource<T> effective = resolveEffectiveSource(sourceObj, destFieldName, breadcrumb);
-                        constructorArgsValues[i] =
-                                getFieldValue(effective.source, effective.fieldName, targetClass, reflectionUtils.getDeclaredField(destFieldName, targetClass), breadcrumb);
+                        return classUtils.getDefaultTypeValue(constructorParameters[i].getType());
                     }
-                });
-        return constructorArgsValues;
+                    EffectiveSource<T> effective = resolveEffectiveSource(sourceObj, destFieldName, breadcrumb);
+                    return getFieldValue(effective.source(), effective.fieldName(), targetClass, reflectionUtils.getDeclaredField(destFieldName, targetClass), breadcrumb);
+                })
+                .toArray(Object[]::new);
     }
 
     /**
@@ -354,19 +389,23 @@ public class TransformerImpl extends AbstractBeanTransformer {
      */
     private String getDestFieldName(final Parameter constructorParameter, final String declaringClassName) {
         String cacheKey = "DestFieldName-" + declaringClassName + "-" + constructorParameter.getName();
-        return cacheManager.getFromCache(cacheKey, String.class)
-                .orElseGet(() -> {
-                    String destFieldName;
-                    if (constructorParameter.isNamePresent()) {
-                        destFieldName = constructorParameter.getName();
-                    } else {
-                        destFieldName = ofNullable(reflectionUtils.getParameterAnnotation(constructorParameter, ConstructorArg.class, declaringClassName))
-                                .map(ConstructorArg::value)
-                                .orElse(null);
-                    }
-                    cacheManager.cacheObject(cacheKey, destFieldName);
-                    return destFieldName;
-                });
+        // Use ABSENT_FIELD_NAME as sentinel so that null results (no compiled name, no @ConstructorArg)
+        // are stored and retrieved from cache correctly rather than causing a cache miss every time.
+        var fromCache = cacheManager.getFromCache(cacheKey, String.class);
+        if (fromCache.isPresent()) {
+            String cached = fromCache.get();
+            return ABSENT_FIELD_NAME.equals(cached) ? null : cached;
+        }
+        String destFieldName;
+        if (constructorParameter.isNamePresent()) {
+            destFieldName = constructorParameter.getName();
+        } else {
+            destFieldName = ofNullable(reflectionUtils.getParameterAnnotation(constructorParameter, ConstructorArg.class, declaringClassName))
+                    .map(ConstructorArg::value)
+                    .orElse(null);
+        }
+        cacheManager.cacheObject(cacheKey, destFieldName, ABSENT_FIELD_NAME);
+        return destFieldName;
     }
 
     /**
@@ -382,9 +421,8 @@ public class TransformerImpl extends AbstractBeanTransformer {
      */
     private <T, K> Object[] getConstructorValuesFromFields(final T sourceObj, final Class<K> targetClass, final String breadcrumb) {
         final List<Field> declaredFields = classUtils.getDeclaredFields(targetClass, true);
-        K k = null;
         return declaredFields.stream()
-                .map(field -> getFieldValue(sourceObj, k, targetClass, field, breadcrumb))
+                .map(field -> getFieldValue(sourceObj, (K) null, targetClass, field, breadcrumb))
                 .toArray(Object[]::new);
     }
 
@@ -449,7 +487,7 @@ public class TransformerImpl extends AbstractBeanTransformer {
 
     private <T, K> Object getFieldValue(final T sourceObj, final K targetObject, final Class<K> targetClass, final Field field, final String breadcrumb) {
         EffectiveSource<T> effective = resolveEffectiveSource(sourceObj, field.getName(), breadcrumb);
-        return getFieldValue(effective.source, effective.fieldName, targetObject, targetClass, field, breadcrumb);
+        return getFieldValue(effective.source(), effective.fieldName(), targetObject, targetClass, field, breadcrumb);
     }
 
     /**
@@ -571,6 +609,9 @@ public class TransformerImpl extends AbstractBeanTransformer {
                 fieldValue = sourceObj;
             } else if (!isFieldTransformerDefined && !settings.isSetDefaultValueForMissingField()) {
                 throw e;
+            } else {
+                log.debug("Field '{}' not found in source type '{}'; field transformer will receive null.",
+                        sourceFieldName, sourceObj.getClass().getName());
             }
         } catch (Exception e) {
             if (!isFieldTransformerDefined) {
@@ -588,23 +629,27 @@ public class TransformerImpl extends AbstractBeanTransformer {
      */
     private Class<?> getSourceFieldType(final Class<?> sourceObjectClass, final String sourceFieldName) {
         String cacheKey = "SourceFieldType-" + sourceObjectClass.getName() + "-" + sourceFieldName;
-        return cacheManager.getFromCache(cacheKey, Class.class)
-                .orElseGet(() -> {
-                    Class<?> classType = null;
-                    try {
-                        classType = reflectionUtils.getDeclaredFieldType(sourceFieldName, sourceObjectClass);
-                    } catch (MissingFieldException e) {
-                        // in case the source field is a primitive type and the destination one is composite,
-                        // the source field type is returned without going in deep
-                        if (classUtils.isPrimitiveType(sourceObjectClass)) {
-                            classType = sourceObjectClass;
-                        } else if (!settings.isSetDefaultValueForMissingField()) {
-                            throw e;
-                        }
-                    }
-                    cacheManager.cacheObject(cacheKey, classType);
-                    return classType;
-                });
+        // Use ABSENT_SOURCE_FIELD_TYPE as sentinel so that null results (field not present in source
+        // when default-value mode is active) are cached and not recomputed on every call.
+        var fromCache = cacheManager.getFromCache(cacheKey, Class.class);
+        if (fromCache.isPresent()) {
+            Class<?> cached = fromCache.get();
+            return cached == ABSENT_SOURCE_FIELD_TYPE ? null : cached;
+        }
+        Class<?> classType = null;
+        try {
+            classType = reflectionUtils.getDeclaredFieldType(sourceFieldName, sourceObjectClass);
+        } catch (MissingFieldException e) {
+            // in case the source field is a primitive type and the destination one is composite,
+            // the source field type is returned without going in deep
+            if (classUtils.isPrimitiveType(sourceObjectClass)) {
+                classType = sourceObjectClass;
+            } else if (!settings.isSetDefaultValueForMissingField()) {
+                throw e;
+            }
+        }
+        cacheManager.cacheObject(cacheKey, classType, ABSENT_SOURCE_FIELD_TYPE);
+        return classType;
     }
 
     /**
@@ -646,21 +691,26 @@ public class TransformerImpl extends AbstractBeanTransformer {
      * @param fieldTransformerKey the field name or the full path to the field to which assign the transformer
      * @return the default type transformer function
      */
+    @SuppressWarnings("rawtypes")
     private FieldTransformer getPrimitiveTypeTransformer(final Class<?> sourceObjectClass, final String sourceFieldName,
                                                          final Field field, final String fieldTransformerKey) {
         String cacheKey = TRANSFORMER_FUNCTION_CACHE_PREFIX + "-" + field.getDeclaringClass().getName() + "-" + fieldTransformerKey + "-" + field.getName();
-        return cacheManager.getFromCache(cacheKey, FieldTransformer.class)
-                .orElseGet(() -> {
-                    FieldTransformer primitiveTypeTransformer = null;
-                    Class<?> sourceFieldType = getSourceFieldType(sourceObjectClass, sourceFieldName);
-                    if (nonNull(sourceFieldType)) {
-                        primitiveTypeTransformer = conversionAnalyzer.getConversionFunction(sourceFieldType, field.getType())
-                                .map(conversionFunction -> new FieldTransformer<>(fieldTransformerKey, conversionFunction))
-                                .orElse(null);
-                    }
-                    cacheManager.cacheObject(cacheKey, primitiveTypeTransformer);
-                    return primitiveTypeTransformer;
-                });
+        // Use NO_OP_FIELD_TRANSFORMER_SENTINEL to cache null results (no conversion applicable).
+        // The sentinel is an identity transformer, so if it leaks past the sentinel check it is still safe.
+        var fromCache = cacheManager.getFromCache(cacheKey, FieldTransformer.class);
+        if (fromCache.isPresent()) {
+            FieldTransformer cached = fromCache.get();
+            return cached == NO_OP_FIELD_TRANSFORMER_SENTINEL ? null : cached;
+        }
+        FieldTransformer primitiveTypeTransformer = null;
+        Class<?> sourceFieldType = getSourceFieldType(sourceObjectClass, sourceFieldName);
+        if (nonNull(sourceFieldType)) {
+            primitiveTypeTransformer = conversionAnalyzer.getConversionFunction(sourceFieldType, field.getType())
+                    .map(conversionFunction -> new FieldTransformer<>(fieldTransformerKey, conversionFunction))
+                    .orElse(null);
+        }
+        cacheManager.cacheObject(cacheKey, primitiveTypeTransformer, NO_OP_FIELD_TRANSFORMER_SENTINEL);
+        return primitiveTypeTransformer;
     }
 
     /**

--- a/bull-bean-transformer/src/main/java/com/expediagroup/beans/transformer/TransformerImpl.java
+++ b/bull-bean-transformer/src/main/java/com/expediagroup/beans/transformer/TransformerImpl.java
@@ -77,14 +77,11 @@ public class TransformerImpl extends AbstractBeanTransformer {
     private static final Class<?> ABSENT_SOURCE_FIELD_TYPE = AbsentFieldType.class;
 
     /**
-     * Sentinel {@link FieldTransformer} cached by {@link #getPrimitiveTypeTransformer} when no
-     * primitive-type conversion is applicable for a given field. Acts as an identity transform so
-     * the caller's {@code nonNull} check still short-circuits correctly without applying any
-     * conversion, and the sentinel is distinguishable from a real transformer via identity ({@code ==}).
+     * Cache key suffix appended to the primary key in {@link #getPrimitiveTypeTransformer} when the
+     * result is {@code null} (no primitive-type conversion is applicable). Storing a {@link Boolean}
+     * marker under this secondary key avoids the need for a sentinel object with an unreachable lambda.
      */
-    @SuppressWarnings("rawtypes")
-    private static final FieldTransformer NO_OP_FIELD_TRANSFORMER_SENTINEL =
-            new FieldTransformer<Object, Object>("__no_conversion__", x -> x);
+    private static final String NULL_PRIMITIVE_TRANSFORMER_SUFFIX = ".nullConversion";
 
     /**
      * Holds a per-thread stack of root source objects for active transformations.
@@ -695,12 +692,12 @@ public class TransformerImpl extends AbstractBeanTransformer {
     private FieldTransformer getPrimitiveTypeTransformer(final Class<?> sourceObjectClass, final String sourceFieldName,
                                                          final Field field, final String fieldTransformerKey) {
         String cacheKey = TRANSFORMER_FUNCTION_CACHE_PREFIX + "-" + field.getDeclaringClass().getName() + "-" + fieldTransformerKey + "-" + field.getName();
-        // Use NO_OP_FIELD_TRANSFORMER_SENTINEL to cache null results (no conversion applicable).
-        // The sentinel is an identity transformer, so if it leaks past the sentinel check it is still safe.
         var fromCache = cacheManager.getFromCache(cacheKey, FieldTransformer.class);
         if (fromCache.isPresent()) {
-            FieldTransformer cached = fromCache.get();
-            return cached == NO_OP_FIELD_TRANSFORMER_SENTINEL ? null : cached;
+            return fromCache.get();
+        }
+        if (cacheManager.getFromCache(cacheKey + NULL_PRIMITIVE_TRANSFORMER_SUFFIX, Boolean.class).isPresent()) {
+            return null;
         }
         FieldTransformer primitiveTypeTransformer = null;
         Class<?> sourceFieldType = getSourceFieldType(sourceObjectClass, sourceFieldName);
@@ -709,7 +706,11 @@ public class TransformerImpl extends AbstractBeanTransformer {
                     .map(conversionFunction -> new FieldTransformer<>(fieldTransformerKey, conversionFunction))
                     .orElse(null);
         }
-        cacheManager.cacheObject(cacheKey, primitiveTypeTransformer, NO_OP_FIELD_TRANSFORMER_SENTINEL);
+        if (primitiveTypeTransformer != null) {
+            cacheManager.cacheObject(cacheKey, primitiveTypeTransformer);
+        } else {
+            cacheManager.cacheObject(cacheKey + NULL_PRIMITIVE_TRANSFORMER_SUFFIX, Boolean.TRUE);
+        }
         return primitiveTypeTransformer;
     }
 

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/populator/ArrayPopulatorTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/populator/ArrayPopulatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2023 Expedia, Inc.
+ * Copyright (C) 2019-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ public class ArrayPopulatorTest {
     private static final String VAL_1 = "val1";
     private static final String VAL_2 = "val2";
     private static final String[] STRING_ARRAY = new String[] {VAL_1, VAL_2};
+    private static final Object[] OBJECT_STRING_ARRAY = new Object[] {VAL_1, VAL_2};
     private static final char CHAR = '\u0000';
     private static final char[] CHAR_ARRAY = new char[] {CHAR};
     private static final int ZERO = 0;
@@ -104,7 +105,12 @@ public class ArrayPopulatorTest {
                 {Character.class, CHAR_ARRAY},
                 {Integer.class, INT_ARRAY},
                 {MixedToFooStaticField.class, createMixedToFooArray()},
-                {Object.class, createBooleanArray()}
+                {Object.class, createBooleanArray()},
+                // isPrimitiveTypeArray=false, isPrimitiveOrSpecialType(String)=true → res=fieldValue (covers 4th branch)
+                {String.class, OBJECT_STRING_ARRAY},
+                // isPrimitiveTypeArray(Object[])=false, isPrimitiveOrSpecialType(Object)=false → else branch,
+                // elements are Strings (primitive type) → lambda TRUE branch covered
+                {Object.class, OBJECT_STRING_ARRAY}
         };
     }
 

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/populator/CollectionPopulatorTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/populator/CollectionPopulatorTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2019-2026 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.beans.populator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.util.List;
+import java.util.Set;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.expediagroup.beans.sample.mixed.MixedToFooStaticField;
+import com.expediagroup.beans.transformer.BeanTransformer;
+
+/**
+ * Unit test for class: {@link CollectionPopulator}.
+ */
+public class CollectionPopulatorTest {
+    private static final MixedToFooStaticField ELEM = new MixedToFooStaticField();
+
+    @Mock
+    private BeanTransformer transformer;
+
+    /**
+     * The class to be tested.
+     */
+    @InjectMocks
+    private CollectionPopulator<MixedToFooStaticField> underTest;
+
+    /**
+     * Initializes mock.
+     */
+    @BeforeClass
+    public void beforeClass() {
+        openMocks(this);
+    }
+
+    /**
+     * Tests that {@code getPopulatedObject} collects into a {@link Set} when {@code fieldType} is {@code Set}.
+     * Covers the true branch of {@code Set.class.isAssignableFrom(fieldType) ? toSet() : toList()}.
+     */
+    @Test
+    public void testGetPopulatedObjectCollectsIntoSetWhenFieldTypeIsSet() {
+        // GIVEN - a source list of non-primitive elements, destination type is Set
+        List<MixedToFooStaticField> sourceList = List.of(ELEM);
+        when(transformer.transform(any(), eq(MixedToFooStaticField.class))).thenReturn(ELEM);
+
+        // WHEN
+        var result = underTest.getPopulatedObject(Set.class, MixedToFooStaticField.class, sourceList, null);
+
+        // THEN
+        assertThat(result).isInstanceOf(Set.class).contains(ELEM);
+    }
+}

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/populator/PopulatorFactoryTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/populator/PopulatorFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2023 Expedia, Inc.
+ * Copyright (C) 2019-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,5 +91,22 @@ public class PopulatorFactoryTest {
         if (isNonNullObjectExpected) {
             assertThat(populator).containsInstanceOf(expectedResult);
         }
+    }
+
+    /**
+     * Tests that an {@link OptionalPopulator} is returned when the destination type is {@link Optional} but the
+     * source type is not. Covers the false branch of {@code Optional.class == sourceObjectClass} combined with
+     * the true branch of {@code Optional.class == destObjectClass}.
+     */
+    @Test
+    @SuppressWarnings({"unchecked"})
+    public void testGetPopulatorReturnsOptionalPopulatorWhenOnlyDestIsOptional() {
+        // GIVEN - dest is Optional, source is not Optional (covers the second condition of the || expression)
+
+        // WHEN
+        Optional<Populator> populator = underTest.getPopulator(Optional.class, String.class, transformer);
+
+        // THEN
+        assertThat(populator).containsInstanceOf(OptionalPopulator.class);
     }
 }

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/AbstractBeanTransformerTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/AbstractBeanTransformerTest.java
@@ -48,13 +48,16 @@ public abstract class AbstractBeanTransformerTest extends AbstractTransformerTes
     }
 
     /**
-     * Initialized mocks.
+     * Initialized mocks and resets all transformer state between tests.
+     * openMocks(this) recreates underTest with fresh TransformerSettings, so individual
+     * settings (mappings, skip list, etc.) are already clean. resetFieldsTransformer() is
+     * still required explicitly because the CacheManager backing store is shared statically
+     * across instances and is not wiped when a new instance is created.
      */
     @BeforeMethod
     void beforeMethod() {
         openMocks(this);
+        underTest.reset();
         underTest.resetFieldsTransformer();
-        underTest.resetFieldsTransformationSkip();
-        underTest.resetFieldsMapping();
     }
 }

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/BeanTransformerTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/BeanTransformerTest.java
@@ -33,6 +33,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.util.Deque;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.testng.annotations.DataProvider;
@@ -67,6 +68,9 @@ public class BeanTransformerTest extends AbstractBeanTransformerTest {
     private static final String GET_TRANSFORMER_VALUE_METHOD_NAME = "getTransformedValue";
     private static final String GET_CONSTRUCTOR_ARGS_VALUES_METHOD_NAME = "getConstructorArgsValues";
     private static final String HANDLE_INJECTION_EXCEPTION_METHOD_NAME = "handleInjectionException";
+    private static final String RESOLVE_EFFECTIVE_SOURCE_METHOD_NAME = "resolveEffectiveSource";
+    private static final String ROOT_SOURCE_STACK_FIELD_NAME = "rootSourceStack";
+    private static final String BREADCRUMB = "bc";
 
     /**
      * Test that is possible to remove a field mapping for a given field.
@@ -530,6 +534,55 @@ public class BeanTransformerTest extends AbstractBeanTransformerTest {
             {"NamesUnavailable_AllAnnotated_returnsTrue", false, true, true},
             {"NamesUnavailable_NotAnnotated_returnsFalse", false, false, false}
         };
+    }
+
+    /**
+     * Test that {@code resolveEffectiveSource} falls through to the default source when a field-name mapping
+     * exists for the resolved breadcrumb key but the root-source stack is empty (no active transform context).
+     * Covers the false branch of {@code mapped != null && !stack.isEmpty()} when the stack is empty.
+     * @throws Exception if the method invocation fails
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testResolveEffectiveSourceWithMappingAndEmptyStackFallsThrough() throws Exception {
+        // GIVEN - add a mapping so "bc.name" → SOURCE_FIELD_NAME (mapped != null)
+        underTest.withFieldMapping(new FieldMapping<>(SOURCE_FIELD_NAME, BREADCRUMB + "." + NAME_FIELD_NAME));
+        Method method = TransformerImpl.class.getDeclaredMethod(
+                RESOLVE_EFFECTIVE_SOURCE_METHOD_NAME, Object.class, String.class, String.class);
+        method.setAccessible(true);
+
+        // WHEN - stack is empty (no active transform), so condition evaluates to false → falls through
+        Object result = method.invoke(underTest, fromFoo, NAME_FIELD_NAME, BREADCRUMB);
+
+        // THEN - returns a non-null EffectiveSource backed by the original sourceObj
+        assertThat(result).isNotNull();
+    }
+
+    /**
+     * Test that the void {@code transform(T, K, String)} method does not push or pop the root source stack
+     * when it is called in a non-root context (stack already contains an item).
+     * Covers the false branch of {@code if (isRoot)} at the beginning and end of the method.
+     * @throws Exception if the field access fails
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testVoidTransformWithPrePopulatedStackDoesNotPushAgain() throws Exception {
+        // GIVEN - pre-populate the stack to simulate a nested (non-root) call
+        Field stackField = TransformerImpl.class.getDeclaredField(ROOT_SOURCE_STACK_FIELD_NAME);
+        stackField.setAccessible(true);
+        ThreadLocal<Deque<Object>> rootSourceStack = (ThreadLocal<Deque<Object>>) stackField.get(underTest);
+        rootSourceStack.get().push(fromFoo);
+
+        MutableToFoo dest = new MutableToFoo();
+        try {
+            // WHEN - isRoot = false because stack is non-empty → push/pop are both skipped
+            underTest.transform(fromFoo, dest, null);
+        } finally {
+            rootSourceStack.get().clear();
+        }
+
+        // THEN - transformation completed and destination was populated
+        assertThat(dest).isNotNull();
     }
 
     /**

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/BeanTransformerTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/BeanTransformerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2023 Expedia, Inc.
+ * Copyright (C) 2019-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import com.expediagroup.beans.conversion.analyzer.ConversionAnalyzer;
 import com.expediagroup.beans.sample.FromFooSimple;
 import com.expediagroup.beans.sample.mutable.MutableToFoo;
 import com.expediagroup.beans.sample.mutable.MutableToFooAdvFields;
+import com.expediagroup.transformer.annotation.ConstructorArg;
 import com.expediagroup.transformer.cache.CacheManager;
 import com.expediagroup.transformer.error.InvalidBeanException;
 import com.expediagroup.transformer.error.MissingFieldException;
@@ -187,6 +188,24 @@ public class BeanTransformerTest extends AbstractBeanTransformerTest {
     }
 
     /**
+     * Test that is possible to remove all the transformation skip settings.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testResetFieldsTransformationSkipWorksProperly() {
+        // GIVEN
+        BeanTransformer beanTransformer = underTest.skipTransformationForField(NAME_FIELD_NAME);
+
+        // WHEN
+        beanTransformer.resetFieldsTransformationSkip();
+        TransformerSettings<String> transformerSettings =
+                (TransformerSettings<String>) REFLECTION_UTILS.getFieldValue(beanTransformer, TRANSFORMER_SETTINGS_FIELD_NAME, TransformerSettings.class);
+
+        // THEN
+        assertThat(transformerSettings.getFieldsToSkip()).isEmpty();
+    }
+
+    /**
      * Test that the method: {@code getSourceFieldValue} raises a {@link NullPointerException} in case any of the parameters null.
      * @throws Exception uf the invocation fails
      */
@@ -321,6 +340,29 @@ public class BeanTransformerTest extends AbstractBeanTransformerTest {
     }
 
     /**
+     * Test that the method: {@code getSourceFieldType} caches and returns {@code null} on second call when
+     * the field does not exist in the source class and default-value-for-missing-field mode is active.
+     * @throws Exception if the invoke method fails
+     */
+    @Test
+    public void testGetSourceFieldTypeReturnsCachedNullForAbsentField() throws Exception {
+        // GIVEN
+        underTest.setDefaultValueForMissingField(true);
+
+        Method getSourceFieldTypeMethod = underTest.getClass().getDeclaredMethod(GET_SOURCE_FIELD_TYPE_METHOD_NAME, Class.class, String.class);
+        getSourceFieldTypeMethod.setAccessible(true);
+
+        // WHEN - first call: field does not exist, default value mode active → returns null, caches ABSENT sentinel
+        Class<?> firstResult = (Class<?>) getSourceFieldTypeMethod.invoke(underTest, FromFooSimple.class, "nonExistentFieldForCacheTest");
+        // WHEN - second call: hits the ABSENT sentinel from cache → returns null without recomputing
+        Class<?> secondResult = (Class<?>) getSourceFieldTypeMethod.invoke(underTest, FromFooSimple.class, "nonExistentFieldForCacheTest");
+
+        // THEN
+        assertThat(firstResult).isNull();
+        assertThat(secondResult).isNull();
+    }
+
+    /**
      * Test that the method: {@code getSourceFieldType} throws {@link MissingFieldException} in case the given field does not exists
      * in the given class and the source object class is not primitive and the default value set for missing fields feature is disabled.
      * @throws Exception if the invoke method fails
@@ -442,6 +484,52 @@ public class BeanTransformerTest extends AbstractBeanTransformerTest {
         verify(classUtils).getDefaultTypeValue(Integer.class);
         assertThat(actual).containsOnly(0);
         restoreUnderTestObject();
+    }
+
+    /**
+     * Test that the {@code canBeInjectedByConstructorParams} lambda correctly evaluates both branches
+     * of the {@code areParameterNamesAvailable || allParameterAnnotatedWith} expression.
+     * @param testCaseDescription the test case description
+     * @param areNamesAvailable whether parameter names are available
+     * @param allAnnotated whether all parameters are annotated with {@link ConstructorArg}
+     * @param expected the expected result
+     * @throws Exception if something goes wrong
+     */
+    @Test(dataProvider = "dataCanBeInjectedByConstructorParamsTesting")
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testCanBeInjectedByConstructorParamsLambdaBranchesWorkCorrectly(final String testCaseDescription,
+            final boolean areNamesAvailable, final boolean allAnnotated, final boolean expected) throws Exception {
+        // GIVEN - use a real Constructor and mock both ClassUtils and CacheManager so the lambda always runs
+        ClassUtils classUtilsMock = mock(ClassUtils.class);
+        CacheManager cacheManagerMock = mock(CacheManager.class);
+        Constructor<?> constructor = String.class.getDeclaredConstructors()[0];
+
+        when(cacheManagerMock.getFromCache(anyString(), any(Class.class))).thenReturn(empty());
+        when(classUtilsMock.areParameterNamesAvailable(constructor)).thenReturn(areNamesAvailable);
+        if (!areNamesAvailable) {
+            when(classUtilsMock.allParameterAnnotatedWith(constructor, ConstructorArg.class)).thenReturn(allAnnotated);
+        }
+        reflectionUtils.setFieldValue(underTest, CLASS_UTILS_FIELD_NAME, classUtilsMock);
+        reflectionUtils.setFieldValue(underTest, CACHE_MANAGER_FIELD_NAME, cacheManagerMock);
+
+        // WHEN
+        boolean actual = underTest.canBeInjectedByConstructorParams(constructor);
+
+        // THEN
+        assertThat(actual).isEqualTo(expected);
+        restoreUnderTestObject();
+    }
+
+    /**
+     * Creates the parameters to be used for testing the {@code canBeInjectedByConstructorParams} lambda branches.
+     * @return parameters to be used for testing the {@code canBeInjectedByConstructorParams} lambda branches.
+     */
+    @DataProvider
+    private Object[][] dataCanBeInjectedByConstructorParamsTesting() {
+        return new Object[][] {
+            {"NamesUnavailable_AllAnnotated_returnsTrue", false, true, true},
+            {"NamesUnavailable_NotAnnotated_returnsFalse", false, false, false}
+        };
     }
 
     /**

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/ImmutableObjectTransformationTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/ImmutableObjectTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2023 Expedia, Inc.
+ * Copyright (C) 2019-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -423,6 +423,35 @@ public class ImmutableObjectTransformationTest extends AbstractBeanTransformerTe
         assertThat(actual).isEqualTo(DEST_FIELD_NAME);
 
         // restore modified objects
+        restoreObjects(getDestFieldNameMethod);
+    }
+
+    /**
+     * Test that {@code getDestFieldName} caches and returns {@code null} on second call when
+     * the parameter has no compiled name and no {@link ConstructorArg} annotation.
+     * @throws Exception the thrown exception
+     */
+    @Test
+    public void testGetDestFieldNameReturnsCachedNullForParameterWithNoAnnotation() throws Exception {
+        // GIVEN - a parameter with no compiled name and no @ConstructorArg annotation
+        Parameter constructorParameter = mock(Parameter.class);
+        when(constructorParameter.isNamePresent()).thenReturn(false);
+        when(constructorParameter.getName()).thenReturn("absentArgParam");
+
+        Method getDestFieldNameMethod = underTest.getClass().getDeclaredMethod(GET_DEST_FIELD_NAME_METHOD_NAME, Parameter.class, String.class);
+        getDestFieldNameMethod.setAccessible(true);
+
+        String uniqueClassName = "com.example.UniqueClassForAbsentCacheTest";
+
+        // WHEN - first call computes null (no annotation) and caches the ABSENT_FIELD_NAME sentinel
+        String firstResult = (String) getDestFieldNameMethod.invoke(underTest, constructorParameter, uniqueClassName);
+        // WHEN - second call hits the ABSENT_FIELD_NAME sentinel from cache and returns null
+        String secondResult = (String) getDestFieldNameMethod.invoke(underTest, constructorParameter, uniqueClassName);
+
+        // THEN
+        assertThat(firstResult).isNull();
+        assertThat(secondResult).isNull();
+
         restoreObjects(getDestFieldNameMethod);
     }
 

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MutableObjectTransformationTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MutableObjectTransformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2023 Expedia, Inc.
+ * Copyright (C) 2019-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -336,6 +336,25 @@ public class MutableObjectTransformationTest extends AbstractBeanTransformerTest
                         (double) fromFooPrimitiveTypes.getPrice(),
                         ACTIVE,
                         fromFooPrimitiveTypes.getUuid());
+        underTest.setPrimitiveTypeConversionEnabled(false);
+    }
+
+    /**
+     * Test that the second transformation with primitive type conversion enabled hits the null-marker
+     * cache entry for fields where source and destination types are the same (no conversion needed).
+     */
+    @Test
+    public void testAutomaticPrimitiveTypeTransformationCachesNullConversionForSameTypeFields() {
+        // GIVEN
+        underTest.setPrimitiveTypeConversionEnabled(true);
+
+        // WHEN - first transform computes and caches a null-marker for fields with no conversion
+        MutableToFooOnlyPrimitiveTypes first = underTest.transform(fromFooPrimitiveTypes, MutableToFooOnlyPrimitiveTypes.class);
+        // WHEN - second transform hits the null-marker cache for same-type fields
+        MutableToFooOnlyPrimitiveTypes second = underTest.transform(fromFooPrimitiveTypes, MutableToFooOnlyPrimitiveTypes.class);
+
+        // THEN
+        assertThat(second).usingRecursiveComparison().isEqualTo(first);
         underTest.setPrimitiveTypeConversionEnabled(false);
     }
 

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MutableObjectTransformationTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MutableObjectTransformationTest.java
@@ -375,6 +375,25 @@ public class MutableObjectTransformationTest extends AbstractBeanTransformerTest
     }
 
     /**
+     * Test that the second transformation hits the cached {@link com.expediagroup.transformer.model.FieldTransformer}
+     * for a primitive conversion, covering the {@code fromCache.isPresent()} true branch.
+     */
+    @Test
+    public void testAutomaticPrimitiveTypeTransformerCacheHitOnSecondTransform() {
+        // GIVEN
+        underTest.setPrimitiveTypeConversionEnabled(true);
+
+        // WHEN - first transform computes and caches the FieldTransformer for primitive conversions (e.g. String → int for "code")
+        underTest.transform(fromFooPrimitiveTypes, MutableToFooOnlyPrimitiveTypes.class);
+        // WHEN - second transform hits the cached FieldTransformer (covers fromCache.isPresent() == true)
+        MutableToFooOnlyPrimitiveTypes second = underTest.transform(fromFooPrimitiveTypes, MutableToFooOnlyPrimitiveTypes.class);
+
+        // THEN
+        assertThat(second).isNotNull();
+        underTest.setPrimitiveTypeConversionEnabled(false);
+    }
+
+    /**
      * Test that both primitive type transformation and custom transformation are executed.
      */
     @Test

--- a/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MutableObjectTransformationTest.java
+++ b/bull-bean-transformer/src/test/java/com/expediagroup/beans/transformer/MutableObjectTransformationTest.java
@@ -303,6 +303,21 @@ public class MutableObjectTransformationTest extends AbstractBeanTransformerTest
     }
 
     /**
+     * Test that calling {@code skipTransformationForField} with no arguments is a no-op and does not skip any fields.
+     */
+    @Test
+    public void testSkipTransformationForFieldWithNoArgsDoesNothing() {
+        // GIVEN
+        underTest.skipTransformationForField();
+
+        // WHEN
+        MutableToFoo actual = underTest.transform(fromFoo, MutableToFoo.class);
+
+        // THEN
+        assertThat(actual).usingRecursiveComparison().isEqualTo(fromFoo);
+    }
+
+    /**
      * Test that, given a set of fields for which the transformation has to be skipped, they are actually skipped.
      */
     @Test
@@ -340,22 +355,23 @@ public class MutableObjectTransformationTest extends AbstractBeanTransformerTest
     }
 
     /**
-     * Test that the second transformation with primitive type conversion enabled hits the null-marker
-     * cache entry for fields where source and destination types are the same (no conversion needed).
+     * Test that the second transformation hits the null-marker cache entry for a primitive destination
+     * field whose source counterpart is absent (default-value mode active, no conversion function found).
      */
     @Test
-    public void testAutomaticPrimitiveTypeTransformationCachesNullConversionForSameTypeFields() {
-        // GIVEN
-        underTest.setPrimitiveTypeConversionEnabled(true);
+    public void testAutomaticPrimitiveTypeTransformationCachesNullConversionForMissingSourceField() {
+        // GIVEN - FromFooSimple has no "age" field; MutableToFooNotExistingFields.age is int (primitive)
+        FromFooSimple fromFooSimple = new FromFooSimple(NAME, ID, ACTIVE);
+        underTest.setPrimitiveTypeConversionEnabled(true).setDefaultValueForMissingField(true);
 
-        // WHEN - first transform computes and caches a null-marker for fields with no conversion
-        MutableToFooOnlyPrimitiveTypes first = underTest.transform(fromFooPrimitiveTypes, MutableToFooOnlyPrimitiveTypes.class);
-        // WHEN - second transform hits the null-marker cache for same-type fields
-        MutableToFooOnlyPrimitiveTypes second = underTest.transform(fromFooPrimitiveTypes, MutableToFooOnlyPrimitiveTypes.class);
+        // WHEN - first transform: no source type → null-marker stored for the "age" field
+        MutableToFooNotExistingFields first = underTest.transform(fromFooSimple, MutableToFooNotExistingFields.class);
+        // WHEN - second transform: null-marker is found in cache → returns null without recomputing
+        MutableToFooNotExistingFields second = underTest.transform(fromFooSimple, MutableToFooNotExistingFields.class);
 
         // THEN
         assertThat(second).usingRecursiveComparison().isEqualTo(first);
-        underTest.setPrimitiveTypeConversionEnabled(false);
+        underTest.setPrimitiveTypeConversionEnabled(false).setDefaultValueForMissingField(false);
     }
 
     /**

--- a/bull-common/src/test/java/com/expediagroup/beans/sample/immutable/ImmutableToFooWithStaticField.java
+++ b/bull-common/src/test/java/com/expediagroup/beans/sample/immutable/ImmutableToFooWithStaticField.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2019-2026 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.beans.sample.immutable;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Sample immutable class that also declares a static (non-final) field.
+ * Used to verify that static non-final fields are correctly excluded when
+ * determining the class type (IMMUTABLE: has final instance fields, no
+ * non-final instance fields).
+ */
+@AllArgsConstructor
+@Getter
+public class ImmutableToFooWithStaticField {
+    /**
+     * Static non-final field — must be ignored by the IS_NOT_FINAL_AND_NOT_STATIC_FIELD filter.
+     */
+    private static int instanceCount = 0;
+
+    /**
+     * Non-static final field — makes this class IMMUTABLE.
+     */
+    private final String name;
+}

--- a/bull-common/src/test/java/com/expediagroup/beans/sample/mutable/MutableToFooAdvFields.java
+++ b/bull-common/src/test/java/com/expediagroup/beans/sample/mutable/MutableToFooAdvFields.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2023 Expedia, Inc.
+ * Copyright (C) 2019-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,5 +48,14 @@ public class MutableToFooAdvFields {
 
     private void setIndex(final String indexNumber) {
         this.indexNumber = indexNumber;
+    }
+
+    public MutableToFooAdvFields setFluent(final String val) {
+        this.indexNumber = val;
+        return this;
+    }
+
+    public void getNone() {
+        // getter-like name with void return — used to cover isSetter/isGetter branch in tests
     }
 }

--- a/bull-common/src/test/java/com/expediagroup/transformer/utils/ClassUtilsTest.java
+++ b/bull-common/src/test/java/com/expediagroup/transformer/utils/ClassUtilsTest.java
@@ -160,6 +160,7 @@ public class ClassUtilsTest {
                 {"Tests that the method returns true if the class is a Byte", Byte.class, true},
                 {"Tests that the method returns true if the class is a Void", Void.class, true},
                 {"Tests that the method returns true if the class is a String", String.class, true},
+                {"Tests that the method returns true if the class is an Enum", ClassType.class, true},
         };
     }
 
@@ -196,6 +197,22 @@ public class ClassUtilsTest {
                 {"Tests that the method returns true if the class is an instance of Date class", Date.class, true},
                 {"Tests that the method returns false if the class is an instance of DateTime class", DateTime.class, false}
         };
+    }
+
+    /**
+     * Tests that {@code isSpecialType} returns true for a synthetic class (JDK dynamic proxy),
+     * covering the true branch of {@code clazz.isSynthetic()}.
+     */
+    @Test
+    public void testIsSpecialTypeReturnsTrueForSyntheticClass() {
+        // GIVEN - lambda classes are hidden/synthetic (isSynthetic() == true)
+        Runnable lambda = () -> { };
+
+        // WHEN
+        boolean actual = underTest.isSpecialType(lambda.getClass());
+
+        // THEN
+        assertThat(actual).isTrue();
     }
 
     /**
@@ -290,6 +307,21 @@ public class ClassUtilsTest {
                 {"Tests that the method returns true if the array is of type Integer[]", PRIMITIVE_INTEGER_ARRAY, true},
                 {"Tests that the method returns false if the array is of type FromFoo[]", NOT_PRIMITIVE_ARRAY, false}
         };
+    }
+
+    /**
+     * Tests that {@code isPrimitiveTypeArray} returns false for a non-array class,
+     * covering the false branch of {@code clazz.isArray()}.
+     */
+    @Test
+    public void testIsPrimitiveArrayTypeReturnsFalseForNonArray() {
+        // GIVEN
+
+        // WHEN
+        boolean actual = underTest.isPrimitiveTypeArray(String.class);
+
+        // THEN
+        assertThat(actual).isFalse();
     }
 
     /**
@@ -422,7 +454,9 @@ public class ClassUtilsTest {
                 {"Tests that the method returns the expected value if the class extends another class and skipFinal is not passed as param",
                     ImmutableToFooSubClass.class, null, EXPECTED_SUB_CLASS_PRIVATE_FIELDS},
                 {"Tests that the method returns the expected value if the skipFinal is enabled", CLASS_WITH_PRIVATE_AND_PUBLIC_FIELDS, true,
-                    EXPECTED_MIXED_CLASS_TOTAL_PRIVATE_NOT_FINAL_FIELDS}
+                    EXPECTED_MIXED_CLASS_TOTAL_PRIVATE_NOT_FINAL_FIELDS},
+                {"Tests that static fields are excluded from private fields", CLASS_WITH_STATIC_FIELDS, false, EXPECTED_NOT_STATIC_FIELDS},
+                {"Tests that the method returns empty list for an interface class (null superclass)", Runnable.class, false, ZERO}
         };
     }
 
@@ -690,7 +724,8 @@ public class ClassUtilsTest {
     private Object[][] dataHasFinalFieldTesting() {
         return new Object[][] {
                 {"Tests that the method returns true if the given class has private final fields", CLASS_WITH_PRIVATE_FINAL_FIELDS_AND_SUB_CLASS, true},
-                {"Tests that the method returns true if the given class has no private final fields", CLASS_WITHOUT_PRIVATE_FINAL_FIELDS, false}
+                {"Tests that the method returns true if the given class has no private final fields", CLASS_WITHOUT_PRIVATE_FINAL_FIELDS, false},
+                {"Tests that the method returns false for an interface with a null superclass", Runnable.class, false}
         };
     }
 
@@ -855,6 +890,21 @@ public class ClassUtilsTest {
 
         // THEN
         assertThat(actual).isEqualTo(EXPECTED_DEFAULT_VALUE);
+    }
+
+    /**
+     * Tests that {@code getDefaultTypeValue} returns null for a non-primitive class,
+     * covering the false branch of {@code isPrimitiveType(objectType)}.
+     */
+    @Test
+    public void testGetDefaultTypeValueReturnsNullForNonPrimitive() {
+        // GIVEN
+
+        // WHEN
+        Object actual = underTest.getDefaultTypeValue(FromFoo.class);
+
+        // THEN
+        assertThat(actual).isNull();
     }
 
     /**
@@ -1057,9 +1107,12 @@ public class ClassUtilsTest {
     @DataProvider
     private Object[][] dataGetConcreteClassTesting() throws Exception {
         Field listField = getField(createFromFoo(), LIST_FIELD_NAME);
+        Field nameField = FromFooSimple.class.getDeclaredField(NAME_FIELD_NAME);
+        nameField.setAccessible(true);
         return new Object[][] {
                 {"Tests that the method returns Object if the field value is null", listField, null, Object.class},
-                {"Tests that the method returns LinkedList if the concrete field class is a LinkedList", listField, LINKED_LIST, LINKED_LIST.getClass()}
+                {"Tests that the method returns LinkedList if the concrete field class is a LinkedList", listField, LINKED_LIST, LINKED_LIST.getClass()},
+                {"Tests that the method returns the field type for a concrete (non-interface) field", nameField, "test", String.class}
         };
     }
 
@@ -1134,6 +1187,24 @@ public class ClassUtilsTest {
                 {"Tests that the method returns an empty optional if the class has no builder", ImmutableToFoo.class, Optional.empty()},
                 {"Tests that the method returns an empty optional if the class has a wrong builder", MutableToFooWithWrongBuilder.class, Optional.empty()}
         };
+    }
+
+    /**
+     * Tests that the method {@link ClassUtils#getInstance(Constructor, Object...)} successfully creates an instance
+     * using a valid no-args constructor, covering the happy path of {@code constructor.newInstance}.
+     *
+     * @throws NoSuchMethodException if the constructor is not found
+     */
+    @Test
+    public void testGetInstanceReturnsANewInstanceWhenConstructorIsValid() throws NoSuchMethodException {
+        // GIVEN
+        Constructor<MutableToFoo> constructor = MutableToFoo.class.getConstructor();
+
+        // WHEN
+        MutableToFoo actual = underTest.getInstance(constructor);
+
+        // THEN
+        assertThat(actual).isNotNull().isInstanceOf(MutableToFoo.class);
     }
 
     /**

--- a/bull-common/src/test/java/com/expediagroup/transformer/utils/ClassUtilsTest.java
+++ b/bull-common/src/test/java/com/expediagroup/transformer/utils/ClassUtilsTest.java
@@ -62,6 +62,7 @@ import com.expediagroup.beans.sample.immutable.ImmutableToFooCustomAnnotation;
 import com.expediagroup.beans.sample.immutable.ImmutableToFooSubClass;
 import com.expediagroup.beans.sample.immutable.ImmutableToFooWithKotlinDefaultConstructor;
 import com.expediagroup.beans.sample.immutable.ImmutableToFooWithOnlySyntheticConstructor;
+import com.expediagroup.beans.sample.immutable.ImmutableToFooWithStaticField;
 import com.expediagroup.beans.sample.mixed.MixedToFoo;
 import com.expediagroup.beans.sample.mixed.MixedToFooMissingConstructor;
 import com.expediagroup.beans.sample.mixed.MixedToFooStaticField;
@@ -351,7 +352,8 @@ public class ClassUtilsTest {
                 {"Tests that the method returns 0 if the given class has no private final fields", CLASS_WITHOUT_PRIVATE_FINAL_FIELDS, ZERO},
                 {"Tests that the method returns the expected value if the class has private final fields", CLASS_WITH_PRIVATE_FINAL_FIELDS, EXPECTED_PRIVATE_FINAL_FIELDS},
                 {"Tests that the method returns the expected value if the class has private final fields and extends another class",
-                    CLASS_WITH_PRIVATE_FINAL_FIELDS_AND_SUB_CLASS, EXPECTED_SUB_CLASS_PRIVATE_FIELDS}
+                    CLASS_WITH_PRIVATE_FINAL_FIELDS_AND_SUB_CLASS, EXPECTED_SUB_CLASS_PRIVATE_FIELDS},
+                {"Tests that static final fields are excluded from private final fields", CLASS_WITH_STATIC_FIELDS, ZERO}
         };
     }
 
@@ -814,7 +816,8 @@ public class ClassUtilsTest {
         return new Object[][] {
                 {"Tests that the method returns immutable if the given class is immutable", ImmutableToFoo.class, ClassType.IMMUTABLE},
                 {"Tests that the method returns mutable if the given class is mutable", MutableToFoo.class, ClassType.MUTABLE},
-                {"Tests that the method returns mixed if the given class contains both final and not fields", MixedToFoo.class, ClassType.MIXED}
+                {"Tests that the method returns mixed if the given class contains both final and not fields", MixedToFoo.class, ClassType.MIXED},
+                {"Tests that static non-final fields are ignored when determining IMMUTABLE class type", ImmutableToFooWithStaticField.class, ClassType.IMMUTABLE}
         };
     }
 

--- a/bull-common/src/test/java/com/expediagroup/transformer/utils/ReflectionUtilsTest.java
+++ b/bull-common/src/test/java/com/expediagroup/transformer/utils/ReflectionUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2023 Expedia, Inc.
+ * Copyright (C) 2019-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,11 +35,14 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -158,7 +161,9 @@ public class ReflectionUtilsTest {
                 {"Tests that the method returns null if the required field is inside a null object", mutableToFoo, NESTED_OBJECT_NAME_FIELD_NAME,
                     String.class, null},
                 {"Tests that the method returns the field value even if there is no getter method defined", createFromFooSimpleNoGetters(),
-                    ID_FIELD_NAME, BigInteger.class, ZERO}
+                    ID_FIELD_NAME, BigInteger.class, ZERO},
+                {"Tests that the method returns the class via getter fallback when field name has no declared field but a matching getter exists",
+                    mutableToFoo, "class", Class.class, MutableToFoo.class}
         };
     }
 
@@ -633,6 +638,53 @@ public class ReflectionUtilsTest {
     }
 
     /**
+     * Tests that the method {@code getMapGenericType} handles a map with a collection value type (e.g. {@code Map<String, List<String>>}),
+     * covering the {@code ParameterizedType} branch with {@code getNestedGenericClass=true} in {@code getArgumentTypeClass}.
+     */
+    @Test
+    public void testMapGenericFieldTypeWorksProperlyForMapWithCollectionValues() {
+        // GIVEN
+        MapElemType keyType = ItemType.builder()
+                .objectClass(String.class)
+                .build();
+        MapElemType elemType = ItemType.builder()
+                .objectClass(List.class)
+                .genericClass(String.class)
+                .build();
+        final MapType expectedMapType = new MapType(keyType, elemType);
+        Field field = underTest.getDeclaredField("complexMap", ImmutableToSubFoo.class);
+
+        // WHEN
+        MapType actual = underTest.getMapGenericType(field.getGenericType(), field.getDeclaringClass().getName(), field.getName());
+
+        // THEN
+        assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(expectedMapType);
+    }
+
+    /**
+     * Tests that the method {@code getMapGenericType} handles a map with wildcard type arguments (e.g. {@code Map<?, ?>}),
+     * covering the {@code WildcardType} branch in {@code getArgumentTypeClass}.
+     */
+    @Test
+    public void testMapGenericFieldTypeWorksProperlyForWildcardMap() {
+        // GIVEN
+        MapElemType wildcardType = ItemType.builder()
+                .objectClass(Object.class)
+                .genericClass(Object.class)
+                .build();
+        final MapType expectedMapType = new MapType(wildcardType, wildcardType);
+        Field field = underTest.getDeclaredField("map", ImmutableToFooAdvFields.class);
+
+        // WHEN
+        MapType actual = underTest.getMapGenericType(field.getGenericType(), field.getDeclaringClass().getName(), field.getName());
+
+        // THEN
+        assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(expectedMapType);
+    }
+
+    /**
      * Tests that the method {@code getGetterMethod} works properly.
      * @throws Exception in case an error occurs
      */
@@ -790,6 +842,154 @@ public class ReflectionUtilsTest {
 
         // THEN
         assertThat(actual).isEqualTo(ZERO);
+    }
+
+    /**
+     * Tests that {@code isSetter} returns false for a method matching the setter name pattern but with more than one parameter,
+     * covering the false branch of {@code method.getParameterTypes().length == 1}.
+     *
+     * @throws NoSuchMethodException if the method is not found
+     */
+    @Test
+    public void testIsSetterReturnsFalseWhenMethodHasMoreThanOneParameter() throws NoSuchMethodException {
+        // GIVEN - StringBuilder.setCharAt(int, char) matches ^set[A-Z].* but has 2 params
+        Method setCharAtMethod = StringBuilder.class.getMethod("setCharAt", int.class, char.class);
+
+        // WHEN
+        boolean actual = underTest.isSetter(setCharAtMethod);
+
+        // THEN
+        assertThat(actual).isFalse();
+    }
+
+    /**
+     * Tests that {@code isSetter} returns false for a method matching the setter name and having one parameter
+     * but returning a non-void type, covering the false branch of {@code method.getReturnType().equals(void.class)}.
+     *
+     * @throws NoSuchMethodException if the method is not found
+     */
+    @Test
+    public void testIsSetterReturnsFalseWhenMethodHasNonVoidReturnType() throws NoSuchMethodException {
+        // GIVEN - setFluent(String) matches ^set[A-Z].*, has 1 param, returns MutableToFooAdvFields (non-void)
+        Method setFluentMethod = MutableToFooAdvFields.class.getMethod("setFluent", String.class);
+
+        // WHEN
+        boolean actual = underTest.isSetter(setFluentMethod);
+
+        // THEN
+        assertThat(actual).isFalse();
+    }
+
+    /**
+     * Tests that {@code isGetter} returns false for a method matching the getter name pattern but with parameters,
+     * covering the false branch of {@code method.getParameterTypes().length == 0}.
+     *
+     * @throws NoSuchMethodException if the method is not found
+     */
+    @Test
+    public void testIsGetterReturnsFalseWhenMethodHasParameters() throws NoSuchMethodException {
+        // GIVEN - AtomicInteger.getAndSet(int) matches ^(get|is)[A-Z].* but has 1 param
+        Method getAndSetMethod = AtomicInteger.class.getMethod("getAndSet", int.class);
+
+        // WHEN
+        boolean actual = underTest.isGetter(getAndSetMethod);
+
+        // THEN
+        assertThat(actual).isFalse();
+    }
+
+    /**
+     * Tests that {@code isGetter} returns false for a method matching the getter name pattern with no parameters
+     * but returning void, covering the false branch of {@code !method.getReturnType().equals(void.class)}.
+     *
+     * @throws NoSuchMethodException if the method is not found
+     */
+    @Test
+    public void testIsGetterReturnsFalseWhenMethodReturnsVoid() throws NoSuchMethodException {
+        // GIVEN - MutableToFooAdvFields.getNone() matches ^(get|is)[A-Z].*, has 0 params, returns void
+        Method getNoneMethod = MutableToFooAdvFields.class.getMethod("getNone");
+
+        // WHEN
+        boolean actual = underTest.isGetter(getNoneMethod);
+
+        // THEN
+        assertThat(actual).isFalse();
+    }
+
+    /**
+     * Tests that {@code getGenericFieldType} returns null for a non-parameterized (raw) field,
+     * covering the false branch of the {@code ParameterizedType} check in {@code getGenericFieldType}.
+     */
+    @Test
+    public void testGetGenericFieldTypeReturnsNullForNonParametrizedField() {
+        // GIVEN - FromFooSimple.id is a plain BigInteger field (not parameterized)
+        Field idField = underTest.getDeclaredField(ID_FIELD_NAME, FromFooSimple.class);
+
+        // WHEN
+        Class<?> actual = underTest.getGenericFieldType(idField);
+
+        // THEN
+        assertThat(actual).isNull();
+    }
+
+    /**
+     * Tests that {@code getMapGenericType} correctly handles a map with lower-bounded wildcard type arguments
+     * (e.g. {@code Map<? super Object, ? super Object>}), covering the false branch of
+     * {@code isEmpty(getLowerBounds())} inside {@code getGenericClassType(WildcardType)}.
+     */
+    @Test
+    public void testMapGenericFieldTypeWorksProperlyForLowerBoundedWildcardMap() {
+        // GIVEN - supertypeMap is Map<? super Object, ? super Object>; getLowerBounds() is non-empty
+        MapElemType supertypeWildcard = ItemType.builder()
+                .objectClass(Object.class)
+                .genericClass(Object.class)
+                .build();
+        final MapType expectedMapType = new MapType(supertypeWildcard, supertypeWildcard);
+        Field field = underTest.getDeclaredField("supertypeMap", ImmutableToFooAdvFields.class);
+
+        // WHEN
+        MapType actual = underTest.getMapGenericType(field.getGenericType(), field.getDeclaringClass().getName(), field.getName());
+
+        // THEN
+        assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(expectedMapType);
+    }
+
+    /**
+     * Tests that {@code getGenericClassType} returns null when called with an empty type-arguments array,
+     * covering the false branch of {@code actualTypeArguments.length != 0}.
+     *
+     * @throws Exception if the private method cannot be accessed
+     */
+    @Test
+    public void testGetGenericClassTypeWithEmptyTypeArgumentsReturnsNull() throws Exception {
+        // GIVEN
+        Method method = ReflectionUtils.class.getDeclaredMethod("getGenericClassType", Type[].class);
+        method.setAccessible(true);
+
+        // WHEN
+        Class<?> actual = (Class<?>) method.invoke(underTest, (Object) new Type[0]);
+
+        // THEN
+        assertThat(actual).isNull();
+    }
+
+    /**
+     * Tests that {@code getArgumentTypeClass} returns null when the argument is a {@link List} instance
+     * (not a {@link Class}, {@link java.lang.reflect.ParameterizedType}, or {@link java.lang.reflect.WildcardType}),
+     * covering the {@code List}-branch of the cache-key expression (L583) and the final {@code else-if} false
+     * branch (L594) in {@code getArgumentTypeClass}.
+     */
+    @Test
+    public void testGetArgumentTypeClassWithListInstanceReturnsNull() {
+        // GIVEN - an ArrayList is a List subtype but not a Type (Class/ParameterizedType/WildcardType)
+        List<String> listArgument = new ArrayList<>();
+
+        // WHEN
+        Class<?> actual = underTest.getArgumentTypeClass(listArgument, "testDeclaringClass", "testField", false);
+
+        // THEN
+        assertThat(actual).isNull();
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,11 @@
         <!-- JaCoCo properties -->
         <jacoco.version>0.8.14</jacoco.version>
         <jacoco.classRatio>1.0</jacoco.classRatio>
-        <jacoco.instructionRatio>0.98</jacoco.instructionRatio>
+        <jacoco.instructionRatio>1.0</jacoco.instructionRatio>
         <jacoco.methodRatio>1.0</jacoco.methodRatio>
-        <jacoco.branchRatio>0.89</jacoco.branchRatio>
-        <jacoco.complexityRatio>0.91</jacoco.complexityRatio>
-        <jacoco.lineRatio>0.98</jacoco.lineRatio>
+        <jacoco.branchRatio>1.0</jacoco.branchRatio>
+        <jacoco.complexityRatio>1.0</jacoco.complexityRatio>
+        <jacoco.lineRatio>1.0</jacoco.lineRatio>
         <!-- Required for coverall jdk >= 9 compatibility -->
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <!-- site properties -->


### PR DESCRIPTION
## Description
**bull-bean-transformer/pom.xml**
- Set slf4j-api scope to compile to enable @Slf4j in production code (parent manages it as test). 

**Populator.java**
- Introduced SHARED_REFLECTION_UTILS and SHARED_CLASS_UTILS static singletons. Both utilities are stateless (all cache state lives in static fields), so sharing a single instance across all Populator instances avoids redundant allocations on every PopulatorFactory.getPopulator() call.

**TransformerImpl.java**
- ThreadLocal stack: replaced ThreadLocal<Object> rootSourceObj with ThreadLocal<Deque<Object>> rootSourceStack using ArrayDeque, with explicit push/pop in finally blocks. Preserves isRoot = stack.isEmpty() semantics for nested transformations. 
- EffectiveSource record: replaced private inner class with a Java record for conciseness.
- Dead variable removed: eliminated dead K k = null in getConstructorValuesFromFields, replaced with (K) null cast inline.
- Debug logging: added @Slf4j + log.debug(...) in getSourceFieldValue when a field is silently not found, rather than failing silently. 
- Null-safe caching sentinels: fixed ineffective null caching in getDestFieldName (using ABSENT_FIELD_NAME = "\0"), getSourceFieldType (using AbsentFieldType sentinel class), and getPrimitiveTypeTransformer (using a Boolean.TRUE marker stored under a secondary key cacheKey + ".nullConversion"). Previously, null results caused a cache miss on every call.
- getConstructorArgsValues refactor: replaced side-effectful IntStream.forEach + pre-allocated array with mapToObj().toArray(), making it safe to parallelize in the future.

**Test improvements**
- AbstractBeanTransformerTest: replaced three individual reset calls with underTest.reset() + underTest.resetFieldsTransformer() with explanatory comments. 
- Added targeted tests to reach 100% JaCoCo coverage: 
- testResetFieldsTransformationSkipWorksProperly — covers resetFieldsTransformationSkip() 
- testGetSourceFieldTypeReturnsCachedNullForAbsentField — covers the ABSENT_SOURCE_FIELD_TYPE sentinel cache-hit branch 
- testGetDestFieldNameReturnsCachedNullForParameterWithNoAnnotation — covers the ABSENT_FIELD_NAME sentinel cache-hit branch
- testAutomaticPrimitiveTypeTransformationCachesNullConversionForSameTypeFields — covers the null-marker cache-hit branch in getPrimitiveTypeTransformer
- testCanBeInjectedByConstructorParamsLambdaBranchesWorkCorrectly — covers the areParameterNamesAvailable=false branches of the || expression inside the canBeInjectedByConstructorParams lambda          

## How Has This Been Tested?

- mvn verify passes on bull-bean-transformer — all JaCoCo checks met (methods=1.0, branches, lines, instructions)
- Full mvn verify on the snapshot passes with BUILD SUCCESS 
- All 114 tests pass (0 failures, 0 errors) 

## Checklist:

- [x] The branch follows the best practices naming convention:
     - Use grouping tokens (words) at the beginning of your branch names.
        * `feature`: Feature I'm adding or expanding
        * `bug`: Bugfix or experiment
        * `wip`: Work in progress; stuff I know won't be finished soon
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My changes have no bad impacts on performances
- [ ] My changes have been tested through Unit Tests and the overall coverage has not decreased. Check the coverall report for your branch: [here](https://coveralls.io/github/ExpediaGroup/bull)
- [ ] Any implemented change has been added in the [CHANGELOG.md](../CHANGELOG.md) file 
- [ ] Any implemented change has been added in the [CHANGELOG-JDK11.md](../CHANGELOG-JDK11.md) file 
- [ ] My changes have been applied on a separate branch too with compatibility with Java 11. Follow this [instructions](https://github.com/ExpediaGroup/bull/blob/master/RELEASE.md#3-prepare-the-jdk11-release) for help.
- [ ] The maven version has been increased. 
